### PR TITLE
Introduce ClojureScript compliment source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target/
 /.cpcache/
 /suitable.jar
+.cljs_*_repl/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# suitable - Addon for Figwheel and Emacs CIDER to aid exploratory development in ClojureScript [![Clojars Project](https://img.shields.io/clojars/v/org.rksm/suitable.svg)](https://clojars.org/org.rksm/suitable)
+# suitable - ClojureScript Completion Toolkit
+
+[![Clojars Project](https://img.shields.io/clojars/v/org.rksm/suitable.svg)](https://clojars.org/org.rksm/suitable)
 
 This project is a code completion backend for interactive repls and editors that
 use runtime introspection to provide "IntelliSense" support. This can be
@@ -13,6 +15,10 @@ and press TAB. Methods and properties of `js/document` will appear — including
 Currently Emacs (via CIDER) and figwheel.main are supported. If you want support
 for your favorite tool please let me know and I'll look into it (no promises,
 though).
+
+It also provides a [compliment custom
+source](https://github.com/alexander-yakushev/compliment/wiki/Custom-sources]
+for ClojureScript so that tooling can depend on it.
 
 ## Demo
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
-{:deps {org.clojure/clojurescript {:mvn/version "[1.9.908,)"}}
+{:deps {org.clojure/clojurescript {:mvn/version "[1.9.908,)"}
+        compliment {:mvn/version "0.3.9"}}
 
  :paths ["src/main"]
 
@@ -21,15 +22,14 @@
                         :extra-deps {com.bhauman/figwheel-main {:mvn/version "RELEASE"}}}
 
            ;; tests
-           :test {:extra-paths ["src/test"]
+           :test {:extra-paths ["src/test" "resources"]
                   :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                           :sha "209b64504cb3bd3b99ecfec7937b358a879f55c1"}
                                cider/cider-nrepl {:mvn/version "RELEASE"}
                                cider/piggieback {:mvn/version "RELEASE"}}
-                  :main-opts ["-m" "cognitect.test-runner"]}
+                  :main-opts ["-m" "cognitect.test-runner" "-d" "src/test"]}
 
            ;; build a jar, https://juxt.pro/blog/posts/pack-maven.html
            :pack {:extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
                                                 :sha "2769a6224bfb938e777906ea311b3daf7d2220f5"}}
                   :main-opts ["-m"]}}}
-

--- a/resources/suitable/cljs/env.cljc
+++ b/resources/suitable/cljs/env.cljc
@@ -1,0 +1,23 @@
+(ns suitable.cljs.env
+  (:require [cljs.env :as env]
+            #?@(:clj [[cljs.analyzer.api :as ana]
+                      [cljs.build.api :as build]
+                      [cljs.compiler.api :as comp]
+                      [clojure.java.io :as io]])))
+
+(def test-namespace "suitable/test_ns.cljs" )
+
+(defn create-test-env []
+  #?(:clj
+     (let [opts (build/add-implicit-options {:cache-analysis true, :output-dir "target/out"})
+           env (env/default-compiler-env opts)]
+       (comp/with-core-cljs env opts
+         (fn []
+           (let [r (io/resource test-namespace)]
+             (assert r (str "Cannot find " test-namespace " on the classpath, did you set it up correctly?"))
+             (ana/analyze-file env r opts))))
+       @env)
+
+     :cljs
+     (do (repl/eval '(require (quote suitable.test-ns)) 'suitable.test-env)
+         @env/*compiler*)))

--- a/resources/suitable/test_macros.clj
+++ b/resources/suitable/test_macros.clj
@@ -1,0 +1,11 @@
+(ns ^{:doc "A test macro namespace"} suitable.test-macros)
+
+(defmacro my-add
+  "This is an addition macro"
+  [a b]
+  `(+ ~a ~b))
+
+(defmacro my-sub
+  "This is a subtraction macro"
+  [a b]
+  `(- ~a ~b))

--- a/resources/suitable/test_ns.cljs
+++ b/resources/suitable/test_ns.cljs
@@ -1,0 +1,22 @@
+(ns ^{:doc "A test namespace"} suitable.test-ns
+  (:refer-clojure :exclude [unchecked-byte while])
+  (:require [clojure.string]
+            [suitable.test-ns-dep :as test-dep :refer [foo-in-dep]])
+  (:require-macros [suitable.test-macros :as test-macros :refer [my-add]])
+  (:import [goog.ui IdGenerator]))
+
+(defrecord TestRecord [a b c])
+
+(def x ::some-namespaced-keyword)
+
+(defn issue-28
+  []
+  (str "https://github.com/clojure-emacs/cljs-tooling/issues/28"))
+
+(defn test-public-fn
+  []
+  42)
+
+(defn- test-private-fn
+  []
+  (inc (test-public-fn)))

--- a/resources/suitable/test_ns_dep.cljs
+++ b/resources/suitable/test_ns_dep.cljs
@@ -1,0 +1,5 @@
+(ns ^{:doc "Dependency of test-ns namespace"} suitable.test-ns-dep)
+
+(defn foo-in-dep [foo] :bar)
+
+(def x ::dep-namespaced-keyword)

--- a/src/main/suitable/compliment/sources/cljs.cljc
+++ b/src/main/suitable/compliment/sources/cljs.cljc
@@ -1,0 +1,312 @@
+(ns suitable.compliment.sources.cljs
+  "Standalone auto-complete library based on cljs analyzer state"
+  (:refer-clojure :exclude [meta])
+  (:require [clojure.set :as set]
+            [compliment.sources :refer [defsource]]
+            [compliment.sources.ns-mappings :as vars]
+            [compliment.utils :as utils :refer [*extra-metadata*]]
+            [suitable.compliment.sources.cljs.analysis :as ana]))
+
+(defn unquote-first
+  "Handles some weird double-quoting in the analyzer"
+  [form]
+  (if (= (first form) 'quote)
+    (first (rest form))
+    form))
+
+(defn normalize-arglists
+  "Take metadata arglists and normalize them.
+  Normalization being mainly removing the quote of the first element and
+  wrapping in a list."
+  [arglists]
+  (some->> arglists
+           (unquote-first)
+           (map pr-str)
+           (apply list)))
+
+(defn- candidate-extra
+  [extra-metadata candidate-meta]
+  (when (and (seq extra-metadata) candidate-meta)
+    (let [extra (select-keys candidate-meta extra-metadata)]
+      (cond-> extra
+        (:arglists extra) (update :arglists normalize-arglists)))))
+
+(defn- candidate-data
+  "Returns a map of candidate data for the given arguments."
+  ([candidate ns type]
+   (candidate-data candidate ns type nil nil))
+  ([candidate ns type meta extra-metadata]
+   (merge {:candidate (str candidate)
+           :type type}
+          (when ns {:ns (str ns)})
+          (when (seq extra-metadata)
+            (candidate-extra extra-metadata meta)))))
+
+(defn- var->type
+  "Returns the candidate type corresponding to the given metadata map."
+  [var]
+  (condp #(get %2 %1) var
+    :protocol :protocol-function
+    :fn-var :function
+    :record :record
+    :protocols :type
+    :protocol-symbol :protocol
+    :var))
+
+(def ^:private special-forms
+  '#{& . case* catch def defrecord* deftype* do finally fn* if js* let*
+     letfn* loop* new ns quote recur set! throw try})
+
+(def ^:private special-form-candidates
+  "Candidate data for all special forms."
+  (for [form special-forms]
+    (candidate-data form 'cljs.core :special-form)))
+
+(defn- all-ns-candidates
+  "Returns candidate data for all namespaces in the environment."
+  [env extra-metadata]
+  ;; recent CLJS versions include data about macro namespaces in the
+  ;; compiler env, but we should not include them in completions or pass
+  ;; them to format-ns unless they're actually required (which is handled
+  ;; by macro-ns-candidates below)
+  (for [[ns meta] (ana/all-ns env)]
+    (candidate-data ns nil :namespace meta extra-metadata)))
+
+(defn- ns-candidates
+  "Returns candidate data for all referred namespaces (and their aliases) in context-ns."
+  [env context-ns extra-metadata]
+  (for [[alias ns] (ana/ns-aliases env context-ns)]
+    (candidate-data alias
+                    (when-not (= alias ns) ns)
+                    :namespace
+                    (ana/ns-meta ns)
+                    extra-metadata)))
+
+(defn- macro-ns-candidates
+  "Returns candidate data for all referred macro namespaces (and their aliases) in
+  context-ns."
+  [env context-ns extra-metadata]
+  (for [[alias ns] (ana/macro-ns-aliases env context-ns)]
+    (candidate-data alias
+                    (when-not (= alias ns) ns)
+                    :namespace
+                    ;; given macros are Clojure code we can simply find-ns
+                    ;; the meta should probably be in the compiler env instead
+                    (ana/ns-meta ns)
+                    extra-metadata)))
+
+(defn- referred-var-candidates
+  "Returns candidate data for all referred vars in context-ns."
+  [env context-ns extra-metadata]
+  (for [[refer qualified-sym] (ana/referred-vars env context-ns)
+        :let [ns (namespace qualified-sym)
+              meta (ana/qualified-symbol-meta env qualified-sym)
+              type (var->type meta)]]
+    (candidate-data refer ns type meta extra-metadata)))
+
+(defn- referred-macro-candidates
+  "Returns candidate data for all referred macros in context-ns."
+  [env context-ns extra-metadata]
+  (for [[refer qualified-sym] (ana/referred-macros env context-ns)
+        :let [ns (namespace qualified-sym)
+              meta (ana/macro-meta env qualified-sym)]]
+    (candidate-data refer ns :macro meta extra-metadata)))
+
+(defn- var-candidates
+  [vars extra-metadata]
+  (for [[name meta] vars
+        :let [qualified-name (:name meta)
+              ns (some-> qualified-name namespace)
+              type (var->type meta)]]
+    (candidate-data name ns type meta extra-metadata)))
+
+(defn- ns-var-candidates
+  "Returns candidate data for all vars defined in ns."
+  [env ns extra-metadata]
+  (var-candidates (ana/ns-vars env ns) extra-metadata))
+
+(defn- core-var-candidates
+  "Returns candidate data for all cljs.core vars visible in context-ns."
+  [env ns extra-metadata]
+  (var-candidates (ana/core-vars env ns) extra-metadata))
+
+(defn- macro-candidates
+  [macros extra-metadata]
+  (for [[name var] macros
+        :let [meta (ana/var-meta var)
+              ns (:ns meta)]]
+    (candidate-data name ns :macro meta extra-metadata)))
+
+(defn- core-macro-candidates
+  "Returns candidate data for all cljs.core macros visible in ns."
+  [env ns extra-metadata]
+  (macro-candidates (ana/core-macros env ns) extra-metadata))
+
+(defn- import-candidates
+  "Returns candidate data for all imports in context-ns."
+  [env context-ns]
+  (flatten
+   (for [[import qualified-name] (ana/imports env context-ns)]
+     [(candidate-data import nil :class)
+      (candidate-data qualified-name nil :class)])))
+
+(defn- keyword-candidates
+  "Returns candidate data for all keyword constants in the environment."
+  [env]
+  (map #(candidate-data % nil :keyword) (ana/keyword-constants env)))
+
+(defn- namespaced-keyword-candidates
+  "Returns all namespaced keywords defined in context-ns."
+  [env context-ns]
+  (when context-ns
+    (for [kw (ana/keyword-constants env)
+          :when (= context-ns (ana/as-sym (namespace kw)))]
+      (candidate-data (str "::" (name kw)) context-ns :keyword))))
+
+(defn- referred-namespaced-keyword-candidates
+  "Returns all namespaced keywords referred in context-ns."
+  [env context-ns]
+  (when context-ns
+    (let [aliases (->> (ana/ns-aliases env context-ns)
+                       (filter (fn [[k v]] (not= k v)))
+                       (into {})
+                       (set/map-invert))]
+      (for [kw (ana/keyword-constants env)
+            :let [ns (ana/as-sym (namespace kw))
+                  alias (get aliases ns)]
+            :when alias]
+        (candidate-data (str "::" alias "/" (name kw)) ns :keyword)))))
+
+(defn- unscoped-candidates
+  "Returns all non-namespace-qualified potential candidates in context-ns."
+  [env context-ns extra-metadata]
+  (concat special-form-candidates
+          (all-ns-candidates env extra-metadata)
+          (ns-candidates env context-ns extra-metadata)
+          (macro-ns-candidates env context-ns extra-metadata)
+          (referred-var-candidates env context-ns extra-metadata)
+          (referred-macro-candidates env context-ns extra-metadata)
+          (ns-var-candidates env context-ns extra-metadata)
+          (core-var-candidates env context-ns extra-metadata)
+          (core-macro-candidates env context-ns extra-metadata)
+          (import-candidates env context-ns)
+          (keyword-candidates env)
+          (namespaced-keyword-candidates env context-ns)
+          (referred-namespaced-keyword-candidates env context-ns)))
+
+(defn- prefix-candidate
+  [prefix candidate-data]
+  (let [candidate (:candidate candidate-data)
+        prefixed-candidate (str prefix "/" candidate)]
+    (assoc candidate-data :candidate prefixed-candidate)))
+
+(defn- prefix-candidates
+  [prefix candidates]
+  (map #(prefix-candidate prefix %) candidates))
+
+(defn- ->ns
+  [env symbol-ns context-ns]
+  (if (ana/find-ns env symbol-ns)
+    symbol-ns
+    (ana/ns-alias env symbol-ns context-ns)))
+
+(defn- ->macro-ns
+  [env symbol-ns context-ns]
+  (if (= symbol-ns 'cljs.core)
+    symbol-ns
+    (ana/macro-ns-alias env symbol-ns context-ns)))
+
+(defn- ns-public-var-candidates
+  "Returns candidate data for all public vars defined in ns."
+  [env ns extra-metadata]
+  (var-candidates (ana/public-vars env ns) extra-metadata))
+
+(defn- ns-macro-candidates
+  "Returns candidate data for all macros defined in ns."
+  [env ns extra-metadata]
+  (-> env
+      (ana/public-macros #?(:clj ns :cljs (ana/add-ns-macros ns)))
+      (macro-candidates extra-metadata)))
+
+(defn- scoped-candidates
+  "Returns all candidates for the namespace of sym. Sym must be
+  namespace-qualified. Macro candidates are included if the namespace has its
+  macros required in context-ns."
+  [env sym context-ns extra-metadata]
+  (let [sym-ns (-> sym ana/as-sym ana/namespace-sym)
+        computed-ns (->ns env sym-ns context-ns)
+        macro-ns (->macro-ns env sym-ns context-ns)
+        sym-ns-as-string (str sym-ns)]
+    (mapcat #(prefix-candidates sym-ns-as-string %)
+            [(ns-public-var-candidates env computed-ns extra-metadata)
+             (when macro-ns
+               (ns-macro-candidates env macro-ns extra-metadata))])))
+
+(defn- potential-candidates
+  "Returns all candidates for sym. If sym is namespace-qualified, the candidates
+  for that namespace will be returned (including macros if the namespace has its
+  macros required in context-ns). Otherwise, all non-namespace-qualified
+  candidates for context-ns will be returned."
+  [env context-ns ^String sym extra-metadata]
+  (if (or (= (.indexOf sym "/") -1) (.startsWith sym ":"))
+    (unscoped-candidates env context-ns extra-metadata)
+    (scoped-candidates env sym context-ns extra-metadata)))
+
+(defn- distinct-candidates
+  "Filters candidates to have only one entry for each value of :candidate. If
+  multiple such entries do exist, the first occurrence is used."
+  [candidates]
+  (map first (vals (group-by :candidate candidates))))
+
+(defn- candidate-match?
+  [candidate prefix]
+  (.startsWith ^String (:candidate candidate) prefix))
+
+#?(:cljs
+   (defn- remove-candidate-macros
+     [candidate]
+     (if (= :namespace (:type candidate))
+       (update candidate :candidate (comp str ana/remove-macros))
+       candidate)))
+
+(defn plain-symbol?
+  "Tests if prefix is a symbol with no / (qualified), : (keyword) and
+  . (segmented namespace)."
+  [s]
+  (re-matches #"[^\/\:\.]+" s))
+
+(defn nscl-symbol?
+  "Tests if prefix looks like a namespace or classname."
+  [x]
+  (re-matches #"[^\/\:\.][^\/\:]+" x))
+
+(def ^:dynamic *compiler-env* nil)
+
+(defn candidates
+  "Returns a sequence of candidate data for completions matching the given
+  prefix string and options.
+
+  It requires the compliment.sources.cljs/*compiler-env* var to be dynamically
+  bound to the ClojureScript compiler env."
+  [prefix ns context]
+  (let [context-ns (try (ns-name ns) (catch Exception _ nil))]
+    (->> (potential-candidates *compiler-env* context-ns prefix *extra-metadata*)
+         #?(:cljs (map remove-candidate-macros))
+         (distinct-candidates)
+         (filter #(candidate-match? % prefix)))))
+
+(defn doc
+  [s ns-str]
+  (let [ns-str (or ns-str "cljs.core")
+        qualified-sym (symbol ns-str s)]
+    (some->
+     (cond
+       (plain-symbol? s) (or (ana/qualified-symbol-meta *compiler-env* qualified-sym)
+                             (ana/macro-meta *compiler-env* qualified-sym))
+       (nscl-symbol? s) (-> s symbol ana/ns-meta)
+       :else nil)
+     (vars/generate-docstring))))
+
+(defsource ::cljs-source
+  :candidates #'candidates
+  :doc #'doc)

--- a/src/main/suitable/compliment/sources/cljs/analysis.cljc
+++ b/src/main/suitable/compliment/sources/cljs/analysis.cljc
@@ -1,0 +1,269 @@
+(ns suitable.compliment.sources.cljs.analysis
+  (:require [clojure.string :as str])
+  (:refer-clojure :exclude [find-ns all-ns ns-aliases]))
+
+(def NSES :cljs.analyzer/namespaces)
+
+(defn as-sym [x]
+  (if x (symbol x)))
+
+(defn namespace-sym
+  "Return the namespace of a fully qualified symbol if possible.
+
+  It leaves the symbol untouched if not."
+  [sym]
+  (if-let [ns (and sym (namespace sym))]
+    (as-sym ns)
+    sym))
+
+(defn name-sym
+  "Return the name of a fully qualified symbol if possible.
+
+  It leaves the symbol untouched if not."
+  [sym]
+  (if-let [n (and sym (name sym))]
+    (as-sym n)
+    sym))
+
+(defn all-ns
+  [env]
+  (->> (NSES env)
+       ;; recent CLJS versions include data about macro namespaces in the
+       ;; compiler env, but we should not include them in completions or pass
+       ;; them to format-ns unless they're actually required
+       (into {} (filter (fn [[_ ns]]
+                          (not (and (contains? ns :macros)
+                                    (= 1 (count ns)))))))))
+
+(defn find-ns
+  [env ns]
+  (get (all-ns env) ns))
+
+(defn add-ns-macros
+  "Append $macros to the input symbol"
+  [sym]
+  (some-> sym
+          (str "$macros")
+          symbol))
+
+(defn remove-macros
+  "Remove $macros from the input symbol"
+  [sym]
+  (some-> sym
+          str
+          (str/replace #"\$macros" "")
+          symbol))
+
+;; Code adapted from clojure-complete (http://github.com/ninjudd/clojure-complete)
+
+(defn imports
+  "Returns a map of [import-name] to [ns-qualified-import-name] for all imports
+  in the given namespace."
+  [env ns]
+  (:imports (find-ns env ns)))
+
+(defn ns-aliases
+  "Returns a map {ns-name-or-alias ns-name} for the given namespace."
+  [env ns]
+  (when-let [found (find-ns env ns)]
+    (let [imports (:imports found)]
+      (->> (:requires found)
+           (filter #(not (contains? imports (key %))))
+           (into {})))))
+
+(defn macro-ns-aliases
+  "Returns a map of [macro-ns-name-or-alias] to [macro-ns-name] for the given namespace."
+  [env ns]
+  (:require-macros (find-ns env ns)))
+
+(defn- expand-refer-map
+  [m]
+  (into {} (for [[k v] m] [k (symbol (str v "/" k))])))
+
+(defn referred-vars
+  "Returns a map of [var-name] to [ns-qualified-var-name] for all referred vars
+  in the given namespace."
+  [env ns]
+  (->> (find-ns env ns)
+       :uses
+       expand-refer-map))
+
+(defn referred-macros
+  "Returns a map of [macro-name] to [ns-qualified-macro-name] for all referred
+  macros in the given namespace."
+  [env ns]
+  (->> (find-ns env ns)
+       :use-macros
+       expand-refer-map))
+
+(defn ns-alias
+  "If sym is an alias to, or the name of, a namespace referred to in ns, returns
+  the name of the namespace; else returns nil."
+  [env sym ns]
+  (get (ns-aliases env ns) (as-sym sym)))
+
+(defn macro-ns-alias
+  "If sym is an alias to, or the name of, a macro namespace referred to in ns,
+  returns the name of the macro namespace; else returns nil."
+  [env sym ns]
+  (get (macro-ns-aliases env ns) (as-sym sym)))
+
+(defn- public?
+  [[_ var]]
+  (not (:private var)))
+
+(defn- named?
+  [[_ var]]
+  (not (:anonymous var)))
+
+(defn- foreign-protocol?
+  [[_ var]]
+  (and (:impls var)
+       (not (:protocol-symbol var))))
+
+(defn- macro?
+  [[_ var]]
+  (:macro (meta var)))
+
+(defn ns-vars
+  "Returns a list of the vars declared in the ns."
+  [env ns]
+  (->> (find-ns env ns)
+       :defs
+       (filter (every-pred named? (complement foreign-protocol?)))
+       (into {})))
+
+(defn public-vars
+  "Returns a list of the public vars declared in the ns."
+  [env ns]
+  (->> (find-ns env ns)
+       :defs
+       (filter (every-pred named? public? (complement foreign-protocol?)))
+       (into {})))
+
+(defn public-macros
+  "Given a namespace return all the public var analysis maps. Analagous to
+  clojure.core/ns-publics but returns var analysis maps not vars.
+
+  Inspired by the ns-publics in cljs.analyzer.api."
+  [env ns]
+  {:pre [(symbol? ns)]}
+  #?(:clj (when (and ns (clojure.core/find-ns ns))
+            (->> (ns-publics ns)
+                 (filter macro?)
+                 (into {})))
+     :cljs (->> (merge
+                 (get-in env [NSES ns :macros])
+                 (get-in env [NSES ns :defs]))
+                (remove (fn [[k v]] (:private v)))
+                (into {}))))
+
+(defn core-vars
+  "Returns a list of cljs.core vars visible to the ns."
+  [env ns]
+  (let [vars (public-vars env 'cljs.core)
+        excludes (:excludes (find-ns env ns))]
+    (apply dissoc vars excludes)))
+
+(defn core-macros
+  "Returns a list of cljs.core macros visible to the ns."
+  [env ns]
+  (let [macros (public-macros env #?(:clj 'cljs.core :cljs 'cljs.core$macros))
+        excludes (:excludes (find-ns env ns))]
+    (apply dissoc macros excludes)))
+
+(def ^:private language-keywords
+  #{:require :require-macros :import
+    :refer :refer-macros :include-macros
+    :refer-clojure :exclude
+    :keys :strs :syms
+    :as :or
+    :pre :post
+    :let :when :while
+
+    ;; reader conditionals
+    :clj :cljs :default
+
+    ;; common meta keywords
+    :private :tag :static
+    :doc :author :arglists
+    :added :const
+
+    ;; spec keywords
+    :req :req-un :opt :opt-un
+    :args :ret :fn
+
+    ;; misc
+    :keywordize-keys :else :gen-class})
+
+(defn keyword-constants
+  "Returns a list of both keyword constants in the environment and
+  language specific ones."
+  [env]
+  ;; using namespace for backward compatibility with Clojure 1.8
+  ;; use qualified-keyword? at some point in the future
+  (concat language-keywords (filter namespace (keys (:cljs.analyzer/constant-table env)))))
+
+;; grabbing directly from cljs.analyzer.api
+
+(defn ns-interns-from-env
+  "Given a namespace return all the var analysis maps. Analagous to
+  clojure.core/ns-interns but returns var analysis maps not vars.
+
+  Directly from cljs.analyzer.api."
+  [env ns]
+  {:pre [(symbol? ns)]}
+  (merge
+   (get-in env [NSES ns :macros])
+   (get-in env [NSES ns :defs])))
+
+(defn sanitize-ns
+  "Add :ns from :name if missing."
+  [m]
+  (-> m
+      (assoc :ns (or (:ns m) (:name m)))
+      (update :ns namespace-sym)
+      (update :name name-sym)))
+
+(defn ns-obj?
+  "Return true if n is a namespace object"
+  [ns]
+  (instance? #?(:clj clojure.lang.Namespace
+                :cljs cljs.core/Namespace)
+             ns))
+
+(defn var-meta
+  "Return meta for the var, we wrap it in order to support both JVM and
+  self-host."
+  [var]
+  (cond-> {}
+    (map? var) (merge var)
+    (var? var) (-> (merge (meta var))
+                   (update :ns #(cond-> % (ns-obj? %) ns-name)))
+    true sanitize-ns
+    #?@(:cljs [true (-> (update :ns remove-macros)
+                        (update :name remove-macros))])))
+
+(defn qualified-symbol-meta
+  "Given a namespace-qualified var name, gets the analyzer metadata for
+  that var."
+  [env sym]
+  {:pre [(symbol? sym)]}
+  (let [ns (find-ns env (namespace-sym sym))]
+    (some-> (:defs ns)
+            (get (name-sym sym))
+            var-meta)))
+
+(defn ns-meta
+  [ns]
+  {:pre [(symbol? ns)]}
+  (meta (clojure.core/find-ns ns)))
+
+(defn macro-meta
+  [env qualified-sym]
+  #?(:clj (var-meta (find-var qualified-sym))
+     :cljs (let [referred-ns (symbol (namespace qualified-sym))]
+             (-> env
+                 (ns-interns-from-env (add-ns-macros referred-ns))
+                 (get refer)
+                 var-meta))))

--- a/src/main/suitable/compliment/sources/cljs/ast.cljc
+++ b/src/main/suitable/compliment/sources/cljs/ast.cljc
@@ -1,0 +1,52 @@
+(ns suitable.compliment.sources.cljs.ast
+  (:require [clojure.pprint :refer [pprint *print-right-margin*]]
+            [clojure.zip :as z])
+  #?(:clj (:import [clojure.lang IPersistentList IPersistentMap IPersistentVector ISeq])))
+
+(def V #?(:clj IPersistentVector
+          :cljs PersistentVector))
+(def M #?(:clj IPersistentMap
+          :cljs PersistentArrayMap))
+(def L #?(:clj IPersistentList
+          :cljs List))
+(def S ISeq)
+
+;; Thx @ Alex Miller! http://www.ibm.com/developerworks/library/j-treevisit/
+(defmulti tree-branch? type)
+(defmethod tree-branch? :default [_] false)
+(defmethod tree-branch? V [v] (not-empty v))
+(defmethod tree-branch? M [m] (not-empty m))
+(defmethod tree-branch? L [l] true)
+(defmethod tree-branch? S [s] true)
+(prefer-method tree-branch? L S)
+
+(defmulti tree-children type)
+(defmethod tree-children V [v] v)
+(defmethod tree-children M [m] (->> m seq (apply concat)))
+(defmethod tree-children L [l] l)
+(defmethod tree-children S [s] s)
+(prefer-method tree-children L S)
+
+(defmulti tree-make-node (fn [node children] (type node)))
+(defmethod tree-make-node V [v children]
+  (vec children))
+(defmethod tree-make-node M [m children]
+  (apply hash-map children))
+(defmethod tree-make-node L [_ children]
+  children)
+(defmethod tree-make-node S [node children]
+  (apply list children))
+(prefer-method tree-make-node L S)
+
+(defn tree-zipper [node]
+  (z/zipper tree-branch? tree-children tree-make-node node))
+
+(defn print-tree
+  "for debugging"
+  [node]
+  (let [all (take-while (complement z/end?) (iterate z/next (tree-zipper node)))]
+    (binding [*print-right-margin* 20]
+      (pprint
+       (->> all
+            (map z/node) (zipmap (range))
+            sort)))))

--- a/src/main/suitable/compliment/sources/cljs/js_introspection.cljs
+++ b/src/main/suitable/compliment/sources/cljs/js_introspection.cljs
@@ -1,0 +1,73 @@
+(ns suitable.compliment.source.cljs.js-introspection
+  (:require [clojure.string :refer [starts-with?]]
+            [goog.object :refer [get] :rename {get oget}]))
+
+(def own-property-descriptors
+  (if (js-in "getOwnPropertyDescriptors" js/Object)
+    ;; ES 6+ version
+    (fn [obj] (js/Object.getOwnPropertyDescriptors obj))
+    ;; ES 5.1 version
+    (fn [obj] (->> obj
+                   js/Object.getOwnPropertyNames
+                   (map (fn [key] [key (js/Object.getOwnPropertyDescriptor obj key)]))
+                   (into {})
+                   clj->js))))
+
+(defn properties-by-prototype
+  ""
+  [obj]
+  (loop [obj obj protos []]
+    (if obj
+      (recur
+       (js/Object.getPrototypeOf obj)
+       (conj protos {:obj obj :props (own-property-descriptors obj)}))
+      protos)))
+
+(defn property-names-and-types
+  ([js-obj] (property-names-and-types js-obj nil))
+  ([js-obj prefix]
+   (let [seen (transient #{})]
+     (for [[i {:keys [obj props]}] (map-indexed vector (properties-by-prototype js-obj))
+           key (js-keys props)
+           :when (and (not (get seen key))
+                      (or (empty? prefix)
+                          (starts-with? key prefix)))]
+       (let [prop (oget props key)]
+         (conj! seen key)
+         {:name key
+          :hierarchy i
+          :type (try
+                  (if-let [value (or (oget prop "value")
+                                     (-> prop (oget "get")
+                                         (apply [])))]
+                    (if (fn? value) "function" "var")
+                    "var")
+                  (catch js/Error e "var"))})))))
+
+(comment
+  (do (require '[clojure.pprint :as pprint :refer [pprint]])
+      (require '[cljs.repl :as repl])
+      (require '[cljs.repl.nashorn :as nashorn]))
+
+  (def special-fns {'test-fn (fn self
+                               ([repl-env analyzer-env form]
+                                (self repl-env analyzer-env form nil))
+                               ([repl-env analyzer-env form repl-opts]
+                                (try
+                                  (println "*****")
+                                  (pprint/pprint (meta (var cljs.repl/eval-cljs)))
+                                  (println "*****")
+                                  (catch Exception e
+                                    (println (.getMessage e))))))})
+
+  (repl/repl (nashorn/repl-env) :special-fns special-fns)
+
+  ;; (-> js/console property-names-and-types pprint)
+  (-> js/document.body property-names-and-types pprint)
+
+  (let [obj (new (fn [x] (this-as this (goog.object/set this "foo" 23))))]
+    (pprint (property-names-and-types obj)))
+
+  (oget js/console "log")
+  (-> js/console property-names-and-types pprint)
+  (-> js/window property-names-and-types pprint))

--- a/src/main/suitable/compliment/sources/cljs_js.cljc
+++ b/src/main/suitable/compliment/sources/cljs_js.cljc
@@ -1,0 +1,245 @@
+(ns suitable.compliment.sources.cljs-js
+  (:require [clojure.pprint :refer [cl-format]]
+            [clojure.string :as str]
+            [clojure.zip :as zip]
+            [compliment.sources :refer [defsource]]
+            [suitable.compliment.sources.cljs.ast :as ast])
+  (:import java.io.StringReader))
+
+(def debug? false)
+
+(defn js-properties-of-object
+  "Returns the properties of the object we get by evaluating `:expr`
+  filtered by all those that start with `prefix`."
+  ([cljs-eval-fn ns expr]
+   (js-properties-of-object cljs-eval-fn ns expr nil))
+  ([cljs-eval-fn ns expr prefix]
+   (try
+     ;; :Not using a single expressiont / eval call here like
+     ;; (do (require ...) (runtime ...))
+     ;; to avoid
+     ;; Compile Warning:  Use of undeclared Var
+     ;;   compliment.sources.cljs.js-introspection/property-names-and-types
+     (let [template "(suitable.compliment.sources.cljs.js-introspection/property-names-and-types ~A ~S)"
+           code (cl-format nil template expr prefix)]
+       (cljs-eval-fn ns "(require 'suitable.compliment.sources.cljs.js-introspection)")
+       (cljs-eval-fn ns code))
+     (catch #?(:clj Exception :cljs js/Error) e {:error e}))))
+
+(defn find-prefix
+  [form]
+  "Tree search for the symbol '__prefix. Returns a zipper."
+  (loop [node (ast/tree-zipper form)]
+    (if (= '__prefix__ (zip/node node))
+      node
+      (when-not (zip/end? node)
+        (recur (zip/next node))))))
+
+(defn thread-form?
+  "True if form looks like the name of a thread macro."
+  [form]
+  (->> form
+       str
+       (re-find #"->")
+       nil?
+       not))
+
+(defn doto-form? [form]
+  (= form 'doto))
+
+(defn expr-for-parent-obj
+  "Given the prefix and the context of a completion request, will try to
+  find an expression that evaluates to the object being accessed."
+  [prefix context]
+  (when-let [form (if (string? context)
+                    (try
+                      (with-in-str context (read *in* nil nil))
+                      (catch Exception _e
+                        (when debug?
+                          (binding [*out* *err*]
+                            (cl-format true "Error reading context: ~s" context)))))
+                    context)]
+    (let [prefix-zipper (find-prefix form)
+          left-sibling (zip/left prefix-zipper)
+          first? (nil? left-sibling)
+          first-sibling (and (not first?) (some-> prefix-zipper zip/leftmost zip/node))
+          first-sibling-in-parent (some-> prefix-zipper zip/up zip/leftmost zip/node)
+          threaded? (if first? (thread-form? first-sibling-in-parent) (thread-form? first-sibling) )
+          doto? (if first? (doto-form? first-sibling-in-parent) (doto-form? first-sibling))
+          dot-fn? (str/starts-with? prefix ".")]
+
+      (letfn [(with-type [type maybe-expr]
+                (when maybe-expr
+                  {:type type
+                   :expr maybe-expr}))]
+        (cond
+          (nil? prefix-zipper) nil
+
+          ;; is it a threading macro?
+          threaded?
+          (with-type :-> (if first?
+                           ;; parent is the thread
+                           (-> prefix-zipper zip/up zip/lefts str)
+                           ;; thread on same level
+                           (-> prefix-zipper zip/lefts str)))
+
+          doto?
+          (with-type :doto (if first?
+                             ;; parent is the thread
+                             (-> prefix-zipper zip/up zip/leftmost zip/right zip/node str)
+                             ;; thread on same level
+                             (-> prefix-zipper zip/leftmost zip/right zip/node str)))
+
+          ;; a .. form: if __prefix__ is a prop deeper than one level we need the ..
+          ;; expr up to that point. If just the object that is accessed is left of
+          ;; prefix, we can take that verbatim.
+          ;; (.. js/console log) => js/console
+          ;; (.. js/console -memory -jsHeapSizeLimit) => (.. js/console -memory)
+          (and first-sibling (#{"." ".."} (str first-sibling)) left-sibling)
+          (with-type :.. (let [lefts (-> prefix-zipper zip/lefts)]
+                           (if (<= (count lefts) 2)
+                             (str (last lefts))
+                             (str lefts))))
+
+          ;; (.. js/window -console (log "foo")) => (.. js/window -console)
+          (and first? (-> prefix-zipper zip/up zip/leftmost zip/node str (= "..")))
+          (with-type :.. (let [lefts (-> prefix-zipper zip/up zip/lefts)]
+                           (if (<= (count lefts) 2)
+                             (str (last lefts))
+                             (str lefts))))
+
+          ;; simple (.foo bar)
+          (and first? dot-fn?)
+          (with-type :. (some-> prefix-zipper zip/right zip/node str)))))))
+
+(def ^:private global-expr-re #"^js/((?:[^\.]+\.)*)([^\.]*)$")
+(def ^:private dot-dash-prefix-re #"^\.-?")
+(def ^:private dash-prefix-re #"^-")
+(def ^:private dot-prefix-re #"\.")
+
+(defn- prepare-eval-data
+  "Build a map of data that we can use to fetch the properties from an
+  object that is the result of some `:expr` when evaled and that is used
+  to convert those properties into candidates for completion."
+  [prefix context]
+  ;; js-prefix is a massaged prefix, base on Cljs interop syntax
+  (if (str/starts-with? prefix "js/")
+    ;; js-prefix could be a global like js/console or global/property like js/console.log
+    (let [[_ dotted-expr js-prefix] (re-matches global-expr-re prefix)
+          expr-parts (keep not-empty (str/split dotted-expr dot-prefix-re))
+          ;; builds an expr like
+          ;; "(this-as this (.. this -window))" for prefix = "js/window.console"
+          ;; or "(this-as this this)" for prefix = "js/window"
+          expr (cl-format nil "(this-as this ~[this~:;(.. this ~{-~A~^ ~})~])"
+                          (count expr-parts) expr-parts)]
+      ;; expr-parts
+      {:js-prefix js-prefix
+       :prepend-to-candidate (str "js/" dotted-expr)
+       :vars-have-dashes? false
+       :expr expr
+       :type :global})
+
+    ;; otherwise js-prefix is just a property name embedded in some expr
+    (let [{:keys [type] :as expr-and-type} (expr-for-parent-obj prefix context)]
+      (assoc expr-and-type
+             :prepend-to-candidate (if (str/starts-with? prefix ".") "." "")
+             :js-prefix (case type
+                          :.. (str/replace prefix dash-prefix-re "")
+                          (str/replace prefix dot-dash-prefix-re ""))
+             :vars-have-dashes? true))))
+
+(def ^:dynamic *cljs-eval-fn* nil)
+
+(defn candidates
+  "Returns a sequence of candidate data for JavaScript completions
+  matching the given prefix string, ns and context.
+
+  It requires the compliment.sources.cljs-js/*cljs-eval-fn* var to be
+  dynamically bound to a function that given a namespace (as string) and
+  cljs code (string) will evaluate it and return the value as a clojure
+  object.
+
+  See `suitable.middleware/cljs-dynamic-completion-handler` for
+  how to setup an eval function with nREPL.
+
+  Currently unsupported options that compliment implements
+  are :extra-metadata :sort-order and :plain-candidates."
+  [prefix ns context]
+  ;; Given some context (the toplevel form that has changed) and the prefix
+  ;; string that represents the last typed input, we try to find out if the
+  ;; context/prefix are object access (property access or method call). If so,
+  ;; we try to extract a form that we can evaluate to get the object that is
+  ;; accessed. If we get the object, we enumerate it's properties and methods
+  ;; and generate a list of matching completions for those.
+  (let [{:keys [js-prefix prepend-to-candidate vars-have-dashes? expr type] :as eval-data}
+        (prepare-eval-data prefix context)
+        global? (#{:global} type)]
+    (when debug?
+      (binding [*out* *err*]
+        (println "Eval data:" eval-data)))
+    (when-let [{error :error properties :value}
+               (and expr (js-properties-of-object *cljs-eval-fn* ns expr js-prefix))]
+      (if error
+        (when debug?
+          (binding [*out* *err*]
+            (println "Error in JS completions:" error)))
+        (for [{:keys [name type]} properties
+              :let [maybe-dash (if (and vars-have-dashes? (= "var" type)) "-" "")
+                    candidate (str prepend-to-candidate maybe-dash name)]
+              :when (str/starts-with? candidate prefix)]
+          {:type type :candidate candidate :ns (if global? "js" expr)})))))
+
+(def doc (constantly nil))
+
+(defsource ::js-interop
+  :candidates #'candidates
+  :doc #'doc)
+
+
+(comment
+
+  (defonce ^{:private true} resolved-vars (atom nil))
+
+  (defn- resolve-vars!
+    "This lazy loads runtime state we depend on so that there are no static
+  dependencies to piggieback or cljs."
+    []
+    (or
+     @resolved-vars
+     (let [piggieback-vars (cond
+                             (resolve 'cider.piggieback/*cljs-compiler-env*)
+                             {:cenv-var (resolve 'cider.piggieback/*cljs-compiler-env*)
+                              :renv-var (resolve 'cider.piggieback/*cljs-repl-env*)
+                              :opts-var (resolve 'cider.piggieback/*cljs-repl-options*)}
+
+                             (resolve 'piggieback.core/*cljs-compiler-env*)
+                             {:cenv-var (resolve 'piggieback.core/*cljs-compiler-env*)
+                              :renv-var (resolve 'piggieback.core/*cljs-repl-env*)
+                              :opts-var (resolve 'piggieback.core/*cljs-repl-options*)}
+
+                             :else nil)
+
+           cljs-vars (do
+                       (require 'cljs.repl)
+                       (require 'cljs.analyzer)
+                       (require 'cljs.env)
+                       {:cljs-cenv-var (resolve 'cljs.env/*compiler*)
+                        :cljs-ns-var (resolve 'cljs.analyzer/*cljs-ns*)
+                        :cljs-evaluate-fn (resolve 'cljs.repl/evaluate)
+                        :cljs-eval-cljs-fn (resolve 'cljs.repl/eval-cljs)
+                        :cljs-load-namespace-fn (resolve 'cljs.repl/load-namespace)})]
+
+       (reset! resolved-vars
+               (merge cljs-vars piggieback-vars)))))
+
+  (def cljs-vars (resolve-vars!))
+
+  (def js-introspection-ns "compliment.source.cljs.js-introspection")
+
+  ((:cljs-evaluate-fn cljs-vars)
+   (:renv-var cljs-vars) "<compliment>" 1
+   (format "!!goog.getObjectByName('%s')" js-introspection-ns))
+
+
+
+  )

--- a/src/test/suitable/compliment/sources/t_cljs.cljc
+++ b/src/test/suitable/compliment/sources/t_cljs.cljc
@@ -1,0 +1,304 @@
+(ns suitable.compliment.sources.t-cljs
+  (:require [clojure.set :as set]
+            [clojure.string :as s]
+            [clojure.test :as test #?(:clj :refer :cljs :refer-macros) [deftest is testing use-fixtures]]
+            [clojure.tools.reader.edn :as edn]
+            [clojure.walk :as walk]
+            [compliment.utils :refer [*extra-metadata*]]
+            [suitable.cljs.env :as cljs-env]
+            [suitable.compliment.sources.cljs :as cljs-sources]))
+
+(use-fixtures :once
+  (fn [f]
+    (binding [cljs-sources/*compiler-env* (cljs-env/create-test-env)]
+      (f))))
+
+(defn completions
+  [prefix & [ns]]
+  (cljs-sources/candidates prefix (some-> ns find-ns) nil))
+
+(defn set=
+  [coll1 coll2 & colls]
+  (apply = (set coll1) (set coll2) (map set colls)))
+
+(deftest sanity
+  (testing "Nothing returned for non-existent prefix"
+    (is (= '()
+           (completions "abcdefghijk")
+           (completions "abcdefghijk" 'suitable.test-ns))))
+
+  (testing "cljs.core candidates returned for new namespaces"
+    (is (= (completions "")
+           (completions "" 'abcdefghijk))))
+
+  (let [all-candidates (completions "" 'suitable.test-ns)]
+    (testing "All candidates have a string for :candidate"
+      (is (every? (comp string? :candidate) all-candidates)))
+
+    (testing "All candidates that should have an :ns, do"
+      (let [filter-fn #(not (#{:import :keyword :namespace :class} (:type %)))
+            filtered-candidates (filter filter-fn all-candidates)]
+        (is (every? :ns filtered-candidates))))
+
+    (testing "All candidates have a valid :type"
+      (let [valid-types #{:function
+                          :class
+                          :keyword
+                          :macro
+                          :namespace
+                          :protocol
+                          :protocol-function
+                          :record
+                          :special-form
+                          :type
+                          :var}]
+        (is (every? (comp valid-types :type) all-candidates))))))
+
+(deftest special-form-completions
+  (testing "Special form"
+    (is (= '({:candidate "throw" :ns "cljs.core" :type :special-form})
+           (completions "thr")))
+
+    (is (set= '({:candidate "def" :ns "cljs.core" :type :special-form}
+                {:candidate "do" :ns "cljs.core" :type :special-form}
+                {:candidate "defrecord*" :ns "cljs.core" :type :special-form}
+                {:candidate "deftype*" :ns "cljs.core" :type :special-form})
+              (->> (completions "d")
+                   (filter #(= :special-form (:type %))))))))
+
+(deftest namespace-completions
+  (testing "Namespace"
+    (is (set= '({:candidate "suitable.test-ns" :type :namespace}
+                {:candidate "suitable.test-ns-dep" :type :namespace})
+              (completions "suitable.t"))))
+
+  (testing "Macro Namespace"
+    (is (set= '({:candidate "suitable.test-ns" :type :namespace}
+                {:candidate "suitable.test-ns-dep" :type :namespace}
+                {:candidate "suitable.test-macros" :type :namespace})
+              (completions "suitable.t" 'suitable.test-ns))))
+
+  (testing "Namespace alias"
+    (is (= '()
+           (completions "test-d")
+           (completions "test-d" 'cljs.user)))
+    (is (= '({:candidate "test-dep" :ns "suitable.test-ns-dep" :type :namespace})
+           (completions "test-d" 'suitable.test-ns)))))
+
+(deftest macro-namespace-completions
+  (testing "Macro namespace"
+    (is (= '()
+           (completions "suitable.test-macros")
+           (completions "suitable.test-macros" 'cljs.user)))
+    (is (= '({:candidate "suitable.test-macros" :type :namespace})
+           (completions "suitable.test-m" 'suitable.test-ns))))
+
+  (testing "Macro namespace alias"
+    (is (= '()
+           (completions "test-m")))
+    (is (= '({:candidate "test-macros" :ns "suitable.test-macros" :type :namespace})
+           (completions "test-m" 'suitable.test-ns)))))
+
+(deftest fn-completions
+  (testing "cljs.core fn"
+    (is (set= '({:candidate "unchecked-add" :ns "cljs.core" :type :function}
+                {:candidate "unchecked-add-int" :ns "cljs.core" :type :function})
+              (completions "unchecked-a")
+              (completions "unchecked-a" 'cljs.user)))
+    (is (set= '({:candidate "cljs.core/unchecked-add" :ns "cljs.core" :type :function}
+                {:candidate "cljs.core/unchecked-add-int" :ns "cljs.core" :type :function})
+              (completions "cljs.core/unchecked-a")
+              (completions "cljs.core/unchecked-a" 'cljs.user))))
+
+  (testing "Excluded cljs.core fn"
+    (is (= '()
+           (completions "unchecked-b" 'suitable.test-ns)))
+    (is (= '({:candidate "cljs.core/unchecked-byte" :ns "cljs.core" :type :function})
+           (completions "cljs.core/unchecked-b" 'suitable.test-ns))))
+
+  (testing "Namespace-qualified fn"
+    (is (= '({:candidate "suitable.test-ns/issue-28" :ns "suitable.test-ns" :type :function})
+           (completions "suitable.test-ns/iss")
+           (completions "suitable.test-ns/iss" 'cljs.user)
+           (completions "suitable.test-ns/iss" 'suitable.test-ns))))
+
+  (testing "Referred fn"
+    (is (= '()
+           (completions "bla")
+           (completions "bla" 'suitable.test-ns)))
+    (is (= '({:candidate "foo-in-dep" :ns "suitable.test-ns-dep" :type :function})
+           (completions "foo" 'suitable.test-ns))))
+
+  (testing "Local fn"
+    (is (= '({:candidate "test-public-fn" :ns "suitable.test-ns" :type :function})
+           (completions "test-pu" 'suitable.test-ns))))
+
+  (testing "Private fn"
+    (is (= '()
+           (completions "test-pri")
+           (completions "test-pri" 'cljs.user)))
+    (is (= '({:candidate "test-private-fn" :ns "suitable.test-ns" :type :function})
+           (completions "test-pri" 'suitable.test-ns))))
+
+  (testing "Fn shadowing macro with same name"
+    (is (= '({:candidate "identical?" :ns "cljs.core" :type :function})
+           (completions "identical?")))))
+
+(deftest macro-completions
+  (testing "cljs.core macro"
+    (is (set= '({:candidate "cond->" :ns "cljs.core" :type :macro}
+                {:candidate "cond->>" :ns "cljs.core" :type :macro})
+              (completions "cond-")
+              (completions "cond-" 'suitable.test-ns)))
+    (is (set= '({:candidate "cljs.core/cond->" :ns "cljs.core" :type :macro}
+                {:candidate "cljs.core/cond->>" :ns "cljs.core" :type :macro})
+              (completions "cljs.core/cond-")
+              (completions "cljs.core/cond-" 'suitable.test-ns))))
+
+  (testing "Excluded cljs.core macro"
+    (is (= '()
+           (completions "whil" 'suitable.test-ns)))
+    (is (= '({:candidate "cljs.core/while" :ns "cljs.core" :type :macro})
+           (completions "cljs.core/whil" 'suitable.test-ns))))
+
+  (testing "Namespace-qualified macro"
+    (is (= '()
+           (completions "suitable.test-macros/non-existent")
+           (completions "suitable.test-macros/non-existent" 'cljs.user)))
+    (is (set= '({:candidate "suitable.test-macros/my-add" :ns "suitable.test-macros" :type :macro}
+                {:candidate "suitable.test-macros/my-sub" :ns "suitable.test-macros" :type :macro})
+              (completions "suitable.test-macros/my-" 'suitable.test-ns))))
+
+  (testing "Referred macro"
+    (is (= '()
+           (completions "non-existent")
+           (completions "non-existent" 'suitable.test-ns)))
+    ;; only my-add cause it is the only one referred
+    (is (= '({:candidate "my-add" :ns "suitable.test-macros" :type :macro})
+           (completions "my-" 'suitable.test-ns)))))
+
+(deftest import-completions
+  (testing "Import"
+    (is (= '()
+           (completions "IdGen")
+           (completions "IdGen" 'cljs.user)))
+    (is (= '({:candidate "IdGenerator" :type :class})
+           (completions "IdGen" 'suitable.test-ns))))
+
+  (testing "Namespace-qualified import"
+    ;; TODO Investigate if this is a bug in the implementation.
+    ;;
+    ;; This test used to pass as would not complete unless you have :import in
+    ;; the ns. It might a change in behavior in the way the compiler fills its
+    ;; env with the newer versions.
+    ;;
+    ;; (is (= '()
+    ;;        (completions "goog.ui.IdGen")
+    ;;        (completions "goog.ui.IdGen" 'cljs.user)))
+
+    (is (= '({:candidate "goog.ui.IdGenerator" :type :namespace})
+           (completions "goog.ui.IdGen" 'suitable.test-ns)))))
+
+(deftest keyword-completions
+  (testing "Keyword"
+    (is (empty? (set/difference (set '({:candidate ":refer-macros" :type :keyword}
+                                       {:candidate ":require-macros" :type :keyword}))
+                                (set (completions ":re")))) "the completion should include ClojureScript-specific keywords."))
+
+  (testing "Local namespaced keyword"
+    (is (= '({:candidate "::some-namespaced-keyword" :ns "suitable.test-ns" :type :keyword})
+           (completions "::so" 'suitable.test-ns)))
+
+    (is (= '()
+           (completions "::i" 'suitable.test-ns))))
+
+  (testing "Referred namespaced keyword"
+    (is (= '()
+           (completions "::test-dep/f" 'suitable.test-ns)))
+
+    (is (= '({:candidate "::test-dep/dep-namespaced-keyword" :ns "suitable.test-ns-dep" :type :keyword})
+           (completions "::test-dep/d" 'suitable.test-ns)))))
+
+(deftest protocol-completions
+  (testing "Protocol"
+    (is (set= '({:candidate "IIndexed" :ns "cljs.core" :type :protocol}
+                {:candidate "IIterable" :ns "cljs.core" :type :protocol})
+              (completions "II"))))
+
+  (testing "Protocol fn"
+    (is (set= '({:candidate "-with-meta" :ns "cljs.core" :type :protocol-function}
+                {:candidate "-write" :ns "cljs.core" :type :protocol-function})
+              (completions "-w")))))
+
+(deftest record-completions
+  (testing "Record"
+    (is (= '({:candidate "TestRecord" :ns "suitable.test-ns" :type :record})
+           (completions "Te" 'suitable.test-ns)))))
+
+(deftest type-completions
+  (testing "Type"
+    (is (set= '({:candidate "ES6Iterator" :ns "cljs.core" :type :type}
+                {:candidate "ES6IteratorSeq" :ns "cljs.core" :type :type})
+              (completions "ES6I")))))
+
+(deftest extra-metadata
+  (testing "Extra metadata: namespace :doc"
+    (binding [*extra-metadata* #{:doc}]
+      (is (set= '({:candidate "suitable.test-ns" :doc "A test namespace" :type :namespace}
+                  {:candidate "suitable.test-ns-dep" :doc "Dependency of test-ns namespace" :type :namespace})
+                (completions "suitable.test-")))))
+
+  (testing "Extra metadata: aliased namespace :doc"
+    (binding [*extra-metadata* #{:doc}]
+      (is (= '({:candidate "test-dep" :doc "Dependency of test-ns namespace" :ns "suitable.test-ns-dep" :type :namespace})
+             (completions "test-d" 'suitable.test-ns)))))
+
+  (testing "Extra metadata: macro namespace :doc"
+    (binding [*extra-metadata* #{:doc}]
+      (is (= '({:candidate "suitable.test-macros" :doc "A test macro namespace" :type :namespace})
+             (completions "suitable.test-m" 'suitable.test-ns)))))
+
+  (testing "Extra metadata: normal var :arglists"
+    (binding [*extra-metadata* #{:arglists}]
+      (is (set= '({:candidate "unchecked-add" :ns "cljs.core" :arglists ("[]" "[x]" "[x y]" "[x y & more]") :type :function}
+                  {:candidate "unchecked-add-int" :ns "cljs.core" :arglists ("[]" "[x]" "[x y]" "[x y & more]") :type :function})
+                (completions "unchecked-a" 'cljs.user)))))
+
+  (testing "Extra metadata: normal var :doc"
+    (binding [*extra-metadata* #{:doc}]
+      (is (set= '({:candidate "unchecked-add" :ns "cljs.core" :doc "Returns the sum of nums. (+) returns 0." :type :function}
+                  {:candidate "unchecked-add-int" :ns "cljs.core" :doc "Returns the sum of nums. (+) returns 0." :type :function})
+                (completions "unchecked-a" 'cljs.user)))))
+
+  (testing "Extra metadata: macro :arglists"
+    (binding [*extra-metadata* #{:arglists}]
+      (is (= '({:candidate "defprotocol" :ns "cljs.core" :arglists ("[psym & doc+methods]") :type :macro})
+             (completions "defproto" 'cljs.user)))))
+
+  (testing "Extra metadata: referred var :arglists"
+    (binding [*extra-metadata* #{:arglists}]
+      (is (= '({:candidate "foo-in-dep" :ns "suitable.test-ns-dep" :arglists ("[foo]") :type :function})
+             (completions "foo" 'suitable.test-ns)))))
+
+  (testing "Extra metadata: referred macro :arglists"
+    (binding [*extra-metadata* #{:arglists}]
+      (is (= '({:candidate "my-add" :ns "suitable.test-macros" :arglists ("[a b]") :type :macro})
+             (completions "my-a" 'suitable.test-ns))))))
+
+(deftest predicates
+  (testing "The plain-symbol? predicate"
+    (is (cljs-sources/plain-symbol? "foo") "should detect a \"plain\" symbol")
+    (is (not (cljs-sources/plain-symbol? "foo.bar")) "should NOT match a namespace")
+    (is (not (cljs-sources/plain-symbol? ":foo")) "should NOT match a keyword")
+    (is (not (cljs-sources/plain-symbol? "::foo/bar")) "should NOT match a qualified keyword")
+    (is (not (cljs-sources/plain-symbol? "foo/bar")) "should NOT match a qualified symbol")))
+
+(deftest docstring-generation
+  (testing "symbol docstring"
+    (is (string? (cljs-sources/doc "map" nil)) "should return the map docstring, defaulting to the cljs.core namespace")
+    (is (string? (cljs-sources/doc "map" "cljs.core")) "should return the map docstring")
+    (is (string? (cljs-sources/doc "my-add" "suitable.test-macros"))))
+
+  (testing "namespace docstring"
+    (is (= "\n  A test macro namespace\n" (cljs-sources/doc "suitable.test-macros" nil)))
+    (is (= "\n  A test namespace\n" (cljs-sources/doc "suitable.test-ns" nil)))))

--- a/src/test/suitable/compliment/sources/t_cljs_js.clj
+++ b/src/test/suitable/compliment/sources/t_cljs_js.clj
@@ -1,0 +1,186 @@
+(ns suitable.compliment.sources.t-cljs-js
+  (:require [clojure.pprint :refer [cl-format]]
+            [clojure.string :refer [starts-with?]]
+            [clojure.test :as t :refer [deftest is run-tests]]
+            [suitable.compliment.sources.cljs-js :as cljs-js]))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; helpers
+
+(defn fake-cljs-eval-fn
+  [expected-expression expected-prefix properties]
+  (fn [ns code]
+    (when-let [[_ expr prefix]
+               (re-matches
+                #"^\(suitable.compliment.sources.cljs.js-introspection/property-names-and-types (.*) \"(.*)\"\)"
+                code)]
+      (if (and (= expr expected-expression)
+               (= prefix expected-prefix))
+        {:error nil
+         :value properties}
+        (is false (cl-format nil "Expected expr / prefix~% ~S / ~S~% passed to fake-js-props-fn does not match actual expr / prefix~% ~S / ~S"
+                             expected-expression expected-prefix
+                             expr prefix))))))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; expr-for-parent-obj
+
+(deftest expr-for-parent-obj
+  (let [state {:special-namespaces ["js"]}
+        tests [ ;; should not trigger object completion
+               {:desc "no object in sight"
+                :symbol-and-context    [".log" "(__prefix__)"]
+                :expected nil}
+
+               {:desc "Normal object/class name is typed, not method or special name."
+                :symbol-and-context    ["bar" "(.log __prefix__)"]
+                :expected nil}
+
+               ;; should trigger object completion
+               {:desc ". method"
+                :symbol-and-context    [".log" "(__prefix__ js/console)"]
+                :expected {:type :. :expr "js/console"}}
+
+               {:desc ". method nested"
+                :symbol-and-context    [".log" "(__prefix__ (.-console js/window) \"foo\")"]
+                :expected {:type :. :expr "(.-console js/window)"}}
+
+               {:desc ".- prop"
+                :symbol-and-context    [".-memory" "(__prefix__ js/console)"]
+                :expected {:type :. :expr "js/console"}}
+
+               {:desc ".- prop nested"
+                :symbol-and-context    [".-memory" "(__prefix__ (.-console js/window) \"foo\")"]
+                :expected {:type :. :expr "(.-console js/window)"}}
+
+               {:desc ".. method"
+                :symbol-and-context    ["log" "(.. js/console __prefix__)"]
+                :expected {:type :.. :expr "js/console"}}
+
+               {:desc ".. method nested"
+                :symbol-and-context    ["log" "(.. js/console (__prefix__ \"foo\"))"]
+                :expected {:type :.. :expr "js/console"}}
+
+               {:desc ".. method chained"
+                :symbol-and-context    ["log" "(.. js/window -console __prefix__)"]
+                :expected {:type :.. :expr "(.. js/window -console)"}}
+
+               {:desc ".. method chained and nested"
+                :symbol-and-context    ["log" "(.. js/window -console (__prefix__ \"foo\"))"]
+                :expected {:type :.. :expr "(.. js/window -console)"}}
+
+               {:desc ".. prop"
+                :symbol-and-context    ["-memory" "(.. js/console __prefix__)"]
+                :expected {:type :.. :expr "js/console"}}
+
+               {:desc "->"
+                :symbol-and-context    [".log" "(-> js/console __prefix__)"]
+                :expected {:type :-> :expr "(-> js/console)"}}
+
+               {:desc "-> (.)"
+                :symbol-and-context    [".log" "(-> js/console (__prefix__ \"foo\"))"]
+                :expected {:type :-> :expr "(-> js/console)"}}
+
+               {:desc "-> chained"
+                :symbol-and-context    [".log" "(-> js/window .-console __prefix__)"]
+                :expected {:type :-> :expr "(-> js/window .-console)"}}
+
+               {:desc "-> (.)"
+                :symbol-and-context    [".log" "(-> js/window .-console (__prefix__ \"foo\"))"]
+                :expected {:type :-> :expr "(-> js/window .-console)"}}
+
+               {:desc "doto"
+                :symbol-and-context    [".log" "(doto (. js/window -console) __prefix__)"]
+                :expected {:type :doto :expr "(. js/window -console)"}}
+
+               {:desc "doto (.)"
+                :symbol-and-context    [".log" "(doto (. js/window -console) (__prefix__ \"foo\"))"]
+                :expected {:type :doto :expr "(. js/window -console)"}}
+
+               {:desc "doto (.)"
+                :symbol-and-context    ["js/cons" "(doto (. js/window -console) (__prefix__ \"foo\"))"]
+                :expected {:type :doto :expr "(. js/window -console)"}}
+
+               {:desc "no prefix"
+                :symbol-and-context    ["xx" "(foo bar (baz))"]
+                :expected nil}]]
+
+    (doseq [{[symbol context] :symbol-and-context :keys [expected desc]} tests]
+      (is (= expected (cljs-js/expr-for-parent-obj symbol context)) desc))))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+;; JS candidates
+
+(deftest global
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(this-as this this)" "c"
+                                                      [{:name "console" :hierarchy 1 :type "var"}
+                                                       {:name "confirm" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "js/console" :ns "js" :type "var"}
+            {:candidate "js/confirm" :ns "js" :type "function"}]
+           (cljs-js/candidates  "js/c" "cljs.user" "")))))
+
+(deftest global-prop
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(this-as this (.. this -console))" "lo"
+                                                      [{:name "log" :hierarchy 1 :type "function"}
+                                                       {:name "clear" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "js/console.log" :ns "js" :type "function"}]
+           (cljs-js/candidates "js/console.lo" "cljs.user" "js/console")))))
+
+(deftest global-prop-2
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(this-as this (.. this -window -console))" "lo"
+                                                      [{:name "log" :hierarchy 1 :type "function"}
+                                                       {:name "clear" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "js/window.console.log" :ns "js" :type "function"}]
+           (cljs-js/candidates "js/window.console.lo" "cljs.user" "js/console")))))
+
+(deftest simple
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "js/console" "l"
+                                                      [{:name "log" :hierarchy 1 :type "function"}
+                                                       {:name "clear" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate ".log" :ns "js/console" :type "function"}]
+           (cljs-js/candidates ".l" "cljs.user" "(__prefix__ js/console)")))
+    (is (= [{:candidate "log" :ns "js/console" :type "function"}]
+           (cljs-js/candidates "l" "cljs.user" "(. js/console __prefix__)")))
+    ;; note: we're testing context with a form here
+    (is (= [{:candidate "log" :ns "js/console" :type "function"}]
+           (cljs-js/candidates "l" "cljs.user" '(.. js/console (__prefix__ "foo")))))))
+
+(deftest dotdot-completion
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "js/foo" "ba"
+                                                      [{:name "bar" :hierarchy 1 :type "var"}
+                                                       {:name "baz" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "-bar" :ns "js/foo" :type "var"}]
+           (cljs-js/candidates "-ba" "cljs.user" "(.. js/foo __prefix__)")))
+    (is (= [{:candidate "baz" :ns "js/foo" :type "function"}]
+           (cljs-js/candidates "ba" "cljs.user" "(.. js/foo __prefix__)")))))
+
+(deftest dotdot-completion-chained+nested
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(.. js/foo zork)" "ba"
+                                                      [{:name "bar" :hierarchy 1 :type "var"}
+                                                       {:name "baz" :hierarchy 1 :type "function"}])]
+    (is (= [{:candidate "-bar" :ns "(.. js/foo zork)" :type "var"}]
+           (cljs-js/candidates "-ba" "cljs.user" "(.. js/foo zork (__prefix__ \"foo\"))")))
+    (is (= [{:candidate "baz" :ns "(.. js/foo zork)" :type "function"}]
+           (cljs-js/candidates "ba" "cljs.user" "(.. js/foo zork (__prefix__ \"foo\"))")))))
+
+;; -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+(comment
+
+  (run-tests 'suitable.compliment.sources.t-cljs-js)
+
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "js/console" "l"
+                                                      [{:name "log" :hierarchy 1 :type "function"}
+                                                       {:name "clear" :hierarchy 1 :type "function"}])]
+    (cljs-js/candidates ".l" "cljs.user" "(__prefix__ js/console)"))
+
+  (binding [cljs-js/*cljs-eval-fn* (fake-cljs-eval-fn "(this-as this this)" "c"
+                                                      [{:name "console" :hierarchy 1 :type "var"}])]
+    (cljs-js/candidates "js/c" "cljs.user" :context ""))
+
+  (cljs-js/expr-for-parent-obj "foo" nil "(__prefix__ foo)")
+  (cljs-js/expr-for-parent-obj ".l" "cljs.user" "(__prefix__ js/console)")
+
+  (with-redefs [cljs-js/js-properties-of-object (fn [obj-expr msg] [])]
+    (cljs-js/candidates ".l" "cljs.user" "(__prefix__ js/console)" nil))
+  )


### PR DESCRIPTION
This patch introduces a ClojureScript `defsource` for compliment.

It is a port of what was before into `cljs-tooling` (kind of, as the code has been ported to `compliment` before that).

The code contains tests that are current passing, with the exception of one -
commented out for future investigation with a `TODO`.

This PR needs to go in for us to fully take advantage of this:
https://github.com/alexander-yakushev/compliment/pull/71

I have also noticed some of the old tests are not passing.

If you want to execute just `compliment` tests you can run:

```shell
clojure -R:test -C:test -m cognitect.test-runner -d src/test -n suitable.compliment.sources.t-cljs

clojure -R:test -C:test -m cognitect.test-runner -d src/test -n suitable.compliment.sources.t-cljs-js
```