### PR TITLE
Fix the compliment doc completion code

### DIFF
--- a/src/main/suitable/compliment/sources/cljs/analysis.cljc
+++ b/src/main/suitable/compliment/sources/cljs/analysis.cljc
@@ -220,10 +220,10 @@
 (defn sanitize-ns
   "Add :ns from :name if missing."
   [m]
-  (-> m
-      (assoc :ns (or (:ns m) (:name m)))
-      (update :ns namespace-sym)
-      (update :name name-sym)))
+  (cond-> m
+    (or (:name m) (:ns m)) (-> (assoc :ns (or (:ns m) (:name m)))
+                               (update :ns namespace-sym)
+                               (update :name name-sym))))
 
 (defn ns-obj?
   "Return true if n is a namespace object"

--- a/src/test/suitable/compliment/sources/t_cljs.cljc
+++ b/src/test/suitable/compliment/sources/t_cljs.cljc
@@ -296,9 +296,9 @@
 (deftest docstring-generation
   (testing "symbol docstring"
     (is (string? (cljs-sources/doc "map" nil)) "should return the map docstring, defaulting to the cljs.core namespace")
-    (is (string? (cljs-sources/doc "map" "cljs.core")) "should return the map docstring")
-    (is (string? (cljs-sources/doc "my-add" "suitable.test-macros"))))
+    (is (string? (cljs-sources/doc "map" (find-ns 'cljs.core))) "should return the map docstring")
+    (is (string? (cljs-sources/doc "my-add" (find-ns 'suitable.test-macros)))))
 
   (testing "namespace docstring"
-    (is (= "\n  A test macro namespace\n" (cljs-sources/doc "suitable.test-macros" nil)))
-    (is (= "\n  A test namespace\n" (cljs-sources/doc "suitable.test-ns" nil)))))
+    (is (= "-------------------------\n\n  A test macro namespace\n" (cljs-sources/doc "suitable.test-macros" nil)))
+    (is (= "-------------------------\n\n  A test namespace\n" (cljs-sources/doc "suitable.test-ns" nil)))))


### PR DESCRIPTION
There were a couple of problems with the doc function taken from
compliment. The main one was that compliment passes a Namespace object as
second argument and we were not handling that. Another problem was that both
analysis/sanitize-ns and the main code path were not handling the empty map
case properly.