### PR TITLE
Handle user namespace in ClojureScript doc completions

### DIFF
--- a/src/main/suitable/compliment/sources/cljs/analysis.cljc
+++ b/src/main/suitable/compliment/sources/cljs/analysis.cljc
@@ -261,9 +261,9 @@
 
 (defn macro-meta
   [env qualified-sym]
-  #?(:clj (var-meta (find-var qualified-sym))
+  #?(:clj (some-> (find-var qualified-sym) var-meta)
      :cljs (let [referred-ns (symbol (namespace qualified-sym))]
-             (-> env
-                 (ns-interns-from-env (add-ns-macros referred-ns))
-                 (get refer)
-                 var-meta))))
+             (some-> env
+                     (ns-interns-from-env (add-ns-macros referred-ns))
+                     (get refer)
+                     var-meta))))


### PR DESCRIPTION
* Handle the user namespace for doc completions

  It seems like compliment is passing the 'user namespace to the doc function
  by default if the namespace is missing. This patch makes so that we check in
  both cljs.user and cljs.core (in this order) if that is the case. We check in
  cljs.core as well because that is were the doc for built-ins lives, rather
  than in cljs.user.

* Make sure we return nil in macro-meta if things are missing.

  We always want to return nil because the main
  suitable.compliment.sources.cljs/doc function relies on that for trying
  alternatives.

